### PR TITLE
fix: role/knative-build-bot update users

### DIFF
--- a/templates/kbuild-bot-role.yaml
+++ b/templates/kbuild-bot-role.yaml
@@ -48,6 +48,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - jenkins.io


### PR DESCRIPTION
Amends https://github.com/jenkins-x-charts/environment-controller/commit/cd425bd219465dd2df9e8005e9c0b980ed2094b4 by @rawlingsj, for a problem I observed recently in our cluster. I had a `user` object with a valid-looking `spec` but empty `user` subfield:

```yaml
spec:
  email: …
  login: …
  name: …
  serviceAccount: …
user: {}
```

(Ref.:  jenkins-x/jx#1421 & jenkins-x/jx#2639. This was after deleting _another_ user object with the opposite issue, which had yielded the `selected more than one user from users.jenkins.io` error.)

Then a PR build failed while trying to create a preview environment:

```
Creating a preview
Commit author email is empty for: …
Looking for commits in: /home/jenkins/go/src/github.com/…/…/
Commit not found: …
Commit author email is empty for: …
Looking for commits in: /home/jenkins/go/src/github.com/…/…/
Commit not found: …
Commit author email is empty for: …
Looking for commits in: /home/jenkins/go/src/github.com/…/…/
Associating user  in users.jenkins.io with email  to git GitProvider user with login … as emails match
Adding label jenkins.io/git-github-userid=… to user  in users.jenkins.io
error: users.jenkins.io "…" is forbidden: User "system:serviceaccount:jx:knative-build-bot" cannot update users.jenkins.io in the namespace "jx"
```

Note the blank `found.Name` & `found.Spec.Email` in `users.Resolve`. Worked around by deleting the remaining user object also.

Anyway, I suspect the usual happy code path is to either find a user, or

```go
return jxClient.JenkinsV1().Users(namespace).Create(new)
```

but perhaps the special case

```go
found, err := jxClient.JenkinsV1().Users(namespace).Update(found)
```

was never tested?

Did not test this directly, but did confirm that the second build of a PR fails reproducibly after deleting all matching user objects, unless an analogous patch is made via `kubectl edit role knative-build-bot`.