### PR TITLE
chore(deps): bump jenkins-x/jenkins-x-builders from 0.1.560 to 0.1.564

### DIFF
--- a/environment-controller/values.yaml
+++ b/environment-controller/values.yaml
@@ -42,7 +42,7 @@ source:
 
 image:
   repository: gcr.io/jenkinsxio/builder-maven
-  tag: 0.1.560
+  tag: 0.1.564
 imagePullPolicy: IfNotPresent
 terminationGracePeriodSeconds: 180
 probe:


### PR DESCRIPTION
Update [jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) from [0.1.560](https://github.com/jenkins-x/jenkins-x-builders/releases/tag/0.1.560) to 0.1.564

Command run was `jx step create pr regex --regex (?m)^\s+repository: gcr.io/jenkinsxio/builder-maven\s+tag: (?P<version>.*) --version 0.1.564 --files prow/values.yaml --files environment-controller/values.yaml --repo https://github.com/jenkins-x-charts/prow.git --repo https://github.com/jenkins-x-charts/environment-controller.git`