### PR TITLE
Upgrade envionment-controller to use latest tekton chart

### DIFF
--- a/environment-controller/requirements.yaml
+++ b/environment-controller/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: tekton
   repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.35
+  version: 0.0.42


### PR DESCRIPTION
`jx gc activities` relies on CompletionTime in PipelineRuns which aren't available in old tekton